### PR TITLE
Fix crash when permission manually close

### DIFF
--- a/filepicker/src/main/java/com/jaiselrahman/filepicker/activity/FilePickerActivity.java
+++ b/filepicker/src/main/java/com/jaiselrahman/filepicker/activity/FilePickerActivity.java
@@ -110,11 +110,7 @@ public class FilePickerActivity extends AppCompatActivity
         recyclerView.addItemDecoration(new DividerItemDecoration(this));
         recyclerView.setItemAnimator(null);
 
-        if (savedInstanceState == null) {
-            if (requestPermission(Manifest.permission.READ_EXTERNAL_STORAGE, REQUEST_WRITE_PERMISSION)) {
-                loadFiles(false);
-            }
-        } else {
+        if (requestPermission(Manifest.permission.READ_EXTERNAL_STORAGE, REQUEST_WRITE_PERMISSION)) {
             loadFiles(false);
         }
 


### PR DESCRIPTION
<!--- Template based on https://www.talater.com/open-source-templates/#/ -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix issue #30. 

## Motivation and Context
Remove `if (savedInstanceState == null) { ... }`
Let permission checking goes to prevent no permissions situation.

## How Has This Been Tested?
Manually tested.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
