### PR TITLE
Fix on select nothing and click ok crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![API](https://img.shields.io/badge/API-14%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=14)
-[![jitPack](https://jitpack.io/v/jaiselrahman/FilePicker.svg)](https://jitpack.io/#jaiselrahman/FilePicker)
+[![jitPack](https://jitpack.io/v/mazenrashed/FilePicker.svg)](https://jitpack.io/#mazenrashed/FilePicker)
 [![Monthly Downloads](https://jitpack.io/v/jaiselrahman/FilePicker/month.svg)](https://jitpack.io/#jaiselrahman/FilePicker)
 [![Weekly Downloads](https://jitpack.io/v/jaiselrahman/FilePicker/week.svg)](https://jitpack.io/#jaiselrahman/FilePicker)
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-FilePicker-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/7002)
@@ -39,7 +39,7 @@ Step 2: Add the dependency
 ```gradle
     dependencies {
         ...
-        implementation 'com.github.jaiselrahman:FilePicker:1.3.2'
+              implementation 'com.github.mazenrashed:FilePicker:1.3.3'
     }
 ```
 

--- a/filepicker/src/main/java/com/jaiselrahman/filepicker/activity/FilePickerActivity.java
+++ b/filepicker/src/main/java/com/jaiselrahman/filepicker/activity/FilePickerActivity.java
@@ -266,10 +266,16 @@ public class FilePickerActivity extends AppCompatActivity
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.done) {
-            Intent intent = new Intent();
-            intent.putExtra(MEDIA_FILES, fileGalleryAdapter.getSelectedItems());
-            setResult(RESULT_OK, intent);
-            finish();
+            ArrayList<MediaFile> selectedFiles = fileGalleryAdapter.getSelectedItems();
+            if (selectedFiles.isEmpty()) {
+                Toast.makeText(this, R.string.must_select_file, Toast.LENGTH_SHORT).show();
+            } else {
+                Intent intent = new Intent();
+                intent.putExtra(MEDIA_FILES, fileGalleryAdapter.getSelectedItems());
+                setResult(RESULT_OK, intent);
+                finish();
+            }
+
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/filepicker/src/main/res/values/strings.xml
+++ b/filepicker/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="selection_count_title">%3$s (%1$d/%2$d)</string>
     <string name="selection_count">%1$d/%2$d</string>
     <string name="permission_not_given">Permission not given</string>
+    <string name="must_select_file">Please select one file at least</string>
 </resources>


### PR DESCRIPTION

## Description
When user click ok, check on the selected files list, if it is empty, the user will see a toast message instead of crash
